### PR TITLE
add and use binned ordinal scale for Chart.js ScatterChart

### DIFF
--- a/src/components/containers/ChartContainer.js
+++ b/src/components/containers/ChartContainer.js
@@ -47,8 +47,8 @@ export default class extends React.Component {
 
             // The API provides y values as numbers between 0 and 1, but we want
             // to display them as percentages.
-            population.data.forEach(dataPoint => {
-                resultData.push({x: dataPoint.x, y: dataPoint.y * 100});
+            population.data.forEach((dataPoint, i) => {
+                resultData.push({x: i, xVal: dataPoint.x, y: dataPoint.y * 100});
             });
 
             formattedData.datasets.push({

--- a/src/components/views/Chart.js
+++ b/src/components/views/Chart.js
@@ -1,6 +1,19 @@
 import React from 'react';
 import { Scatter as ScatterChart, Bar as BarChart } from 'react-chartjs-2';
+import Chart from 'chart.js';
+import Ticks from 'chart.js/src/core/core.ticks';
 
+import OrdinalScale from '../../lib/OrdinalScale';
+
+
+const defaultConfig = {
+    position: 'bottom',
+    ticks: {
+        callback: Ticks.formatters.linear
+    }
+};
+
+Chart.scaleService.registerScaleType('ordinal', OrdinalScale, defaultConfig);
 
 export default props => {
     const chartWidth = props.asOverlay ? null : 500;
@@ -41,12 +54,20 @@ export default props => {
                             },
                         }],
                         xAxes: [{
+                            type: 'ordinal',
                             scaleLabel: {
                                 display: true,
                                 labelString: xUnit,
                             },
                             ticks: {
-                                callback: label => label.toLocaleString('en-US'),
+                                callback: (val, i, vals) => {
+                                    // Storing this in a var for readability.
+                                    // We use the first line's X values as indices to set the ticks
+                                    // which would be a bad idea if they were wildly different.
+                                    // Our use case allows for this.
+                                    const result = props.data.datasets[0].data[val];
+                                    return result ? result.xVal : '';
+                                }
                             },
                         }],
                     },

--- a/src/lib/OrdinalScale.js
+++ b/src/lib/OrdinalScale.js
@@ -1,0 +1,181 @@
+import Chart from 'chart.js';
+import defaults from 'chart.js/src/core/core.defaults';
+import helpers from 'chart.js/src/helpers/index';
+
+
+// Basically a copy of chart.js' default liner scale with an overridden
+// getLabelForIndex(). This would be unnecessary if LinearScale was exported
+// but by defining our own scale we can update Chart.js safely.
+export default Chart.LinearScaleBase.extend({
+    determineDataLimits: function() {
+        var me = this;
+        var opts = me.options;
+        var chart = me.chart;
+        var data = chart.data;
+        var datasets = data.datasets;
+        var isHorizontal = me.isHorizontal();
+        var DEFAULT_MIN = 0;
+        var DEFAULT_MAX = 1;
+
+        function IDMatches(meta) {
+            return isHorizontal ? meta.xAxisID === me.id : meta.yAxisID === me.id;
+        }
+
+        // First Calculate the range
+        me.min = null;
+        me.max = null;
+
+        var hasStacks = opts.stacked;
+        if (hasStacks === undefined) {
+            helpers.each(datasets, function(dataset, datasetIndex) {
+                if (hasStacks) {
+                    return;
+                }
+
+                var meta = chart.getDatasetMeta(datasetIndex);
+                if (chart.isDatasetVisible(datasetIndex) && IDMatches(meta) &&
+                    meta.stack !== undefined) {
+                    hasStacks = true;
+                }
+            });
+        }
+
+        if (opts.stacked || hasStacks) {
+            var valuesPerStack = {};
+
+            helpers.each(datasets, function(dataset, datasetIndex) {
+                var meta = chart.getDatasetMeta(datasetIndex);
+                var key = [
+                    meta.type,
+                    // we have a separate stack for stack=undefined datasets when the opts.stacked is undefined
+                    ((opts.stacked === undefined && meta.stack === undefined) ? datasetIndex : ''),
+                    meta.stack
+                ].join('.');
+
+                if (valuesPerStack[key] === undefined) {
+                    valuesPerStack[key] = {
+                        positiveValues: [],
+                        negativeValues: []
+                    };
+                }
+
+                // Store these per type
+                var positiveValues = valuesPerStack[key].positiveValues;
+                var negativeValues = valuesPerStack[key].negativeValues;
+
+                if (chart.isDatasetVisible(datasetIndex) && IDMatches(meta)) {
+                    helpers.each(dataset.data, function(rawValue, index) {
+                        var value = +me.getRightValue(rawValue);
+                        if (isNaN(value) || meta.data[index].hidden) {
+                            return;
+                        }
+
+                        positiveValues[index] = positiveValues[index] || 0;
+                        negativeValues[index] = negativeValues[index] || 0;
+
+                        if (opts.relativePoints) {
+                            positiveValues[index] = 100;
+                        } else if (value < 0) {
+                            negativeValues[index] += value;
+                        } else {
+                            positiveValues[index] += value;
+                        }
+                    });
+                }
+            });
+
+            helpers.each(valuesPerStack, function(valuesForType) {
+                var values = valuesForType.positiveValues.concat(valuesForType.negativeValues);
+                var minVal = helpers.min(values);
+                var maxVal = helpers.max(values);
+                me.min = me.min === null ? minVal : Math.min(me.min, minVal);
+                me.max = me.max === null ? maxVal : Math.max(me.max, maxVal);
+            });
+
+        } else {
+            helpers.each(datasets, function(dataset, datasetIndex) {
+                var meta = chart.getDatasetMeta(datasetIndex);
+                if (chart.isDatasetVisible(datasetIndex) && IDMatches(meta)) {
+                    helpers.each(dataset.data, function(rawValue, index) {
+                        var value = +me.getRightValue(rawValue);
+                        if (isNaN(value) || meta.data[index].hidden) {
+                            return;
+                        }
+
+                        if (me.min === null) {
+                            me.min = value;
+                        } else if (value < me.min) {
+                            me.min = value;
+                        }
+
+                        if (me.max === null) {
+                            me.max = value;
+                        } else if (value > me.max) {
+                            me.max = value;
+                        }
+                    });
+                }
+            });
+        }
+
+        me.min = isFinite(me.min) && !isNaN(me.min) ? me.min : DEFAULT_MIN;
+        me.max = isFinite(me.max) && !isNaN(me.max) ? me.max : DEFAULT_MAX;
+
+        // Common base implementation to handle ticks.min, ticks.max, ticks.beginAtZero
+        this.handleTickRangeOptions();
+    },
+    getTickLimit: function() {
+        var maxTicks;
+        var me = this;
+        var tickOpts = me.options.ticks;
+
+        if (me.isHorizontal()) {
+            maxTicks = Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(me.width / 50));
+        } else {
+            // The factor of 2 used to scale the font size has been experimentally determined.
+            var tickFontSize = helpers.valueOrDefault(tickOpts.fontSize, defaults.global.defaultFontSize);
+            maxTicks = Math.min(tickOpts.maxTicksLimit ? tickOpts.maxTicksLimit : 11, Math.ceil(me.height / (2 * tickFontSize)));
+        }
+
+        return maxTicks;
+    },
+    // Called after the ticks are built. We need
+    handleDirectionalChanges: function() {
+        if (!this.isHorizontal()) {
+            // We are in a vertical orientation. The top value is the highest. So reverse the array
+            this.ticks.reverse();
+        }
+    },
+    getLabelForIndex: function(index, datasetIndex) {
+        return this.chart.data.datasets[datasetIndex].data[index].xVal;
+    },
+    // Utils
+    getPixelForValue: function(value) {
+        // This must be called after fit has been run so that
+        // this.left, this.top, this.right, and this.bottom have been defined
+        var me = this;
+        var start = me.start;
+
+        var rightValue = +me.getRightValue(value);
+        var pixel;
+        var range = me.end - start;
+
+        if (me.isHorizontal()) {
+            pixel = me.left + (me.width / range * (rightValue - start));
+            return Math.round(pixel);
+        }
+
+        pixel = me.bottom - (me.height / range * (rightValue - start));
+        return Math.round(pixel);
+    },
+    getValueForPixel: function(pixel) {
+        var me = this;
+        var isHorizontal = me.isHorizontal();
+        var innerDimension = isHorizontal ? me.width : me.height;
+        var offset = (isHorizontal ? pixel - me.left : me.bottom - pixel) / innerDimension;
+        return me.start + ((me.end - me.start) * offset);
+    },
+    getPixelForTick: function(index) {
+        return this.getPixelForValue(this.ticksAsNumbers[index]);
+    }
+});


### PR DESCRIPTION
Definitely not ideal but this should work going forward. I left the copied linear scale's non-ES2015 style since we shouldn't need to touch it once it's defined.