### PR TITLE
Remove the "completed" property in the API

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -18,7 +18,6 @@ def experiments(request):
             'id': d.id,
             'slug': d.slug,
             'name': d.name,
-            'completed': True,  # TODO
             'enabled': d.enabled,
         })
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,14 +24,12 @@ class TestExperiments(DataTestCase):
                     'id': self.dataset.id,
                     'slug': self.dataset.slug,
                     'name': self.dataset.name,
-                    'completed': True,
                     'enabled': True,
                 },
                 {
                     'id': self.dataset_older.id,
                     'slug': self.dataset_older.slug,
                     'name': self.dataset_older.name,
-                    'completed': True,
                     'enabled': False,
                 },
             ]


### PR DESCRIPTION
This property isn't being read by the front-end and could cause some
confusion. There is some talk about having a "completed" state that is
different than an "enabled" state, but that seems pretty unlikely and we
can bring this back with real data if and when we need to.