### PR TITLE
Don't show paginator when search is being used

### DIFF
--- a/src/components/containers/ExperimentContainer.js
+++ b/src/components/containers/ExperimentContainer.js
@@ -79,10 +79,13 @@ class ExperimentContainer extends React.Component {
         } else if (experimentFetch.rejected) {
             return <Error message={experimentFetch.reason.message} />;
         } else if (experimentFetch.fulfilled) {
-            let visibleMetricIds;
+            let visibleMetricIds = [];
+            let searchActive = false;
+
             if (this.state.sifter && this.state.searchPhrase) {
                 const matchedIndices = this.state.sifter.search(this.state.searchPhrase, { fields: ['name'] }).items.map(m => m.id);
                 visibleMetricIds = experimentFetch.value.metrics.filter((_, index) => matchedIndices.includes(index)).map(m => m.id);
+                searchActive = true;
             } else {
                 visibleMetricIds = visiblePaginatorMembers(this.allMetricIds, this.itemsPerPage, this.state.pageNumber);
             }
@@ -104,6 +107,7 @@ class ExperimentContainer extends React.Component {
                     itemsPerPage={this.itemsPerPage}
                     numItems={this.allMetricIds.length}
                     visibleMetricIds={visibleMetricIds}
+                    searchActive={searchActive}
                 />
             );
         }

--- a/src/components/views/Experiment.js
+++ b/src/components/views/Experiment.js
@@ -98,6 +98,17 @@ export default class extends React.Component {
             );
         }
 
+        let maybePaginator = null;
+        if (!this.props.searchActive) {
+            maybePaginator = (
+                <Paginator
+                    initialPage={this.props.initialPage - 1}
+                    pageCount={Math.ceil(this.props.numItems / this.props.itemsPerPage)}
+                    onPageChange={this.props.onPageChange}
+                />
+            );
+        }
+
         return (
             <div>
                 <article id="experiment">
@@ -140,11 +151,7 @@ export default class extends React.Component {
                             />
                         ))}
                     </section>
-                    <Paginator
-                        initialPage={this.props.initialPage - 1}
-                        pageCount={Math.ceil(this.props.numItems / this.props.itemsPerPage)}
-                        onPageChange={this.props.onPageChange}
-                    />
+                    {maybePaginator}
                 </article>
                 {maybeMetricOverlay}
             </div>


### PR DESCRIPTION
The paginator doesn't do anything in this circumstance, so there's no
point in showing it.