### PR TITLE
force charts that have no categories defined to go through lineChart …

### DIFF
--- a/src/components/containers/ChartContainer.js
+++ b/src/components/containers/ChartContainer.js
@@ -102,7 +102,7 @@ export default class extends React.Component {
             datasets: [],
         };
 
-        if (isLineType) {
+        if (isLineType || !data.categories) {
             formattedData['labels'] = data.populations[0].data.map(dp => dp.x);
         } else {
             formattedData['labels'] = data.categories;


### PR DESCRIPTION
This really shouldn't happen but as we've witnessed it can. For some reason it didn't generate an error on first render even though it was undefined - on second render it would error out.