### PR TITLE
tighten up space in experiment header

### DIFF
--- a/src/components/views/Experiment.js
+++ b/src/components/views/Experiment.js
@@ -114,7 +114,7 @@ export default class extends React.Component {
             <div>
                 <article id="experiment">
                     <h2>{this.props.name || this.props.slug}</h2>
-                    <section id="experiment-details" className={maybeDescription ? 'with-description' : 'without-description'}>
+                    <section id="experiment-details">
                         <h3>Details</h3>
                         {maybeDescription}
                         <section id="experiment-counts">

--- a/src/components/views/styl/Application.styl
+++ b/src/components/views/styl/Application.styl
@@ -7,8 +7,8 @@ body {
 
 #application {
   display: grid;
-  grid-row-gap: 20px;
-  padding: 20px;
+  grid-row-gap: $global-gap;
+  padding: $global-gap;
   width: 1200px;
   margin: 0 auto;
 }

--- a/src/components/views/styl/Experiment.styl
+++ b/src/components/views/styl/Experiment.styl
@@ -1,10 +1,9 @@
 @import 'includes/variables';
 
-$grid-gap = 30px;
 
 #experiment {
     display: grid;
-    grid-gap: 30px;
+    grid-gap: $global-gap;
 
     h2 {
         margin-bottom: 0;
@@ -25,24 +24,9 @@ $grid-gap = 30px;
 }
 
 #experiment-details {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-column-gap: 50px;
-    grid-row-gap: 10px;
-
     border-bottom: 1px solid $gray;
-    padding-bottom: $grid-gap;
+    padding-bottom: 15px;
 
-    &.with-description {
-        grid-template-areas:
-            "top top"\
-            "bottom-left bottom-right";
-    };
-
-    &.without-description {
-        grid-template-areas:
-            "bottom-left bottom-right";
-    }
     dt {
         font-weight: bold;
         clear: left;
@@ -58,11 +42,17 @@ $grid-gap = 30px;
 }
 
 #experiment-description {
-    grid-area: top;
+    margin-bottom: $global-gap;
+
+    p {
+        margin: 0;
+    }
 }
 
 #experiment-counts {
-    grid-area: bottom-left;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: $global-gap;
 }
 
 #experiment-authors {
@@ -98,7 +88,7 @@ $grid-gap = 30px;
 
 #experiment-metrics {
     display: grid;
-    grid-gap: $grid-gap;
+    grid-gap: $global-gap;
     grid-template-columns: 1fr 1fr;
 }
 
@@ -115,7 +105,7 @@ $grid-gap = 30px;
     margin-bottom: -$vertical-spacing;
 
     h4 {
-        margin-bottom: $vertical-spacing;
+        display: none;
     }
 
     h5 {

--- a/src/components/views/styl/includes/variables.styl
+++ b/src/components/views/styl/includes/variables.styl
@@ -1,3 +1,4 @@
 $search-box-height = 30px;
+$global-gap = 30px; // Distance between visually padded page elements.
 
 $gray = #7f7f7f;


### PR DESCRIPTION
This also accounts for a description which would go above the counts (when available). Simplifies the CSS and markup a bit.

![](https://i.imgur.com/eV5Xox1.png)