### PR TITLE
Upgrade Postgres to 9.5.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6.5-alpine
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,4 @@ services:
       - DJANGO_SETTINGS_MODULE=backend.settings.local
 
   db:
-    image: postgres:9.5
+    image: postgres:9.5.12


### PR DESCRIPTION
Heroku backups currently do not support versions of Postgres before this
patch version.

https://help.heroku.com/YNH1ZJUS/why-am-i-getting-pg_restore-archiver-unsupported-version-1-13-in-file-header-error-with-pg_restore