### PR TITLE
Make metric-details a class and merge Stylus rules

### DIFF
--- a/src/components/views/Metric.js
+++ b/src/components/views/Metric.js
@@ -61,7 +61,7 @@ export default withRouter(props => {
 
                     <Icon className="chart-button" name="arrows-alt" title="Fullscreen" onClick={() => um.setQueryParameter('chart', props.id)} />
                 </div>
-                <section id="metric-details">
+                <section className="metric-details">
                     <h5>Details</h5>
                     {buildNValuesDL(props.nValues)}
                 </section>

--- a/src/components/views/styl/Metric.styl
+++ b/src/components/views/styl/Metric.styl
@@ -49,18 +49,15 @@ canvas {
     justify-self: start;
 }
 
-#metric-details {
+.metric-details {
     display: grid;
     grid-row-gap: $grid-row-gap;
+    margin-bottom: 20px;
 
     /* Intentionally hidden. Adds value semantically, but not visually. */
     h5 {
         display: none;
     }
-}
-
-#metric-details {
-    margin-bottom: 20px;
 
     dl {
         display: grid;
@@ -80,6 +77,7 @@ canvas {
             }
         }
     }
+
     dt {
         border-radius: 3px;
         color: #fff;
@@ -91,6 +89,7 @@ canvas {
         white-space: nowrap;
         width: 140px;
     }
+
     dd {
         background-color: #fff;
         border-radius: 3px;


### PR DESCRIPTION
The metric-details ID should actually be a class because elements with
that name appear multiple times per page.