### PR TITLE
show realtime experiments in a new detail page

### DIFF
--- a/src/components/containers/ExperimentsTableContainer.js
+++ b/src/components/containers/ExperimentsTableContainer.js
@@ -55,7 +55,10 @@ export default class extends React.Component {
             visibleExperiments = this.props.experiments.filter((_, index) => matchedIndices.includes(index));
             searchActive = true;
         } else {
-            const sortedExperiments = reverseSortedByProperty(this.props.experiments, 'creationDate');
+            // Sort visible experiments by 'creationDate' first then by 'realtime'.
+            let sortedExperiments = reverseSortedByProperty(this.props.experiments, 'creationDate');
+            sortedExperiments = reverseSortedByProperty(sortedExperiments, 'realtime');
+
             visibleExperiments = visiblePaginatorMembers(sortedExperiments, this.itemsPerPage, this.state.pageNumber);
         }
 

--- a/src/components/containers/MonitoringChartContainer.js
+++ b/src/components/containers/MonitoringChartContainer.js
@@ -9,10 +9,13 @@ import Loading from '../views/Loading';
 class MonitoringChartContainer extends React.Component {
     constructor(props) {
         super(props);
+        this.colors = [];
 
-        this.colors = props.colors.map(color => {
-            return `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        });
+        if (props.colors) {
+            this.colors = props.colors.map(color => {
+                return `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+            });
+        }
     }
 
     render() {
@@ -32,21 +35,23 @@ class MonitoringChartContainer extends React.Component {
 
             if (!emptyDataFound) {
                 Object.keys(dataFetch.value.population).forEach((cohort, i) => {
-                    data.push({
+                    const dataLine = {
                         x: dataFetch.value.population[cohort].map(item => new Date(item.window)),
                         y: dataFetch.value.population[cohort].map(item => item.count),
                         type: 'scatter',
                         mode: 'lines+points',
-                        name: cohort,
-                        line: {color: this.colors[i]}
-                    });
+                        name: cohort
+                    };
+
+                    if (this.colors.length) dataLine['line'] = {color: this.colors[i]};
+                    data.push(dataLine);
                 });
                 return (
                     <MonitoringChart
                         title={this.props.title}
-                        colors={this.colors}
                         data={data}
                         fullWidth={this.props.fullWidth}
+                        size={this.props.size}
                     />
                 );
             } else {

--- a/src/components/containers/RealtimeExperimentContainer.js
+++ b/src/components/containers/RealtimeExperimentContainer.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { withRouter } from 'react-router-dom';
+
+import MonitoringChartContainer from '../containers/MonitoringChartContainer';
+
+
+class RealtimeExperimentContainer extends React.Component {
+    render() {
+        const slug = this.props.match.params.experimentSlug;
+        const size = {width: 900, height: 400};
+
+        return (
+            <article id="experiment">
+                <h2>{slug}</h2>
+                <div className="monitoring-charts-remix">
+                    <p>
+                        These are real-time enrollment charts for experiments that are not yet imported. Once
+                        the nightly import job finishes they will appear on the detailed experiment page.
+                    </p>
+                    <MonitoringChartContainer
+                        endpoint={`${process.env.REACT_APP_API_URL}/experiments/${slug}/realtime-enrolls/`}
+                        title="Enrollments (5min)"
+                        refreshMins={5}
+                        size={size}
+                    />
+                    <MonitoringChartContainer
+                        endpoint={`${process.env.REACT_APP_API_URL}/experiments/${slug}/realtime-unenrolls/`}
+                        title="Unenrollments (5min)"
+                        refreshMins={5}
+                        size={size}
+                    />
+                </div>
+            </article>
+        );
+    }
+}
+
+export default withRouter(RealtimeExperimentContainer);

--- a/src/components/containers/RealtimeExperimentContainer.js
+++ b/src/components/containers/RealtimeExperimentContainer.js
@@ -4,35 +4,33 @@ import { withRouter } from 'react-router-dom';
 import MonitoringChartContainer from '../containers/MonitoringChartContainer';
 
 
-class RealtimeExperimentContainer extends React.Component {
-    render() {
-        const slug = this.props.match.params.experimentSlug;
-        const size = {width: 900, height: 400};
+function RealtimeExperimentContainer(props) {
+    const slug = this.props.match.params.experimentSlug;
+    const size = {width: 900, height: 400};
 
-        return (
-            <article id="experiment">
-                <h2>{slug}</h2>
-                <div className="monitoring-charts-remix">
-                    <p>
-                        These are real-time enrollment charts for experiments that are not yet imported. Once
-                        the nightly import job finishes they will appear on the detailed experiment page.
-                    </p>
-                    <MonitoringChartContainer
-                        endpoint={`${process.env.REACT_APP_API_URL}/experiments/${slug}/realtime-enrolls/`}
-                        title="Enrollments (5min)"
-                        refreshMins={5}
-                        size={size}
-                    />
-                    <MonitoringChartContainer
-                        endpoint={`${process.env.REACT_APP_API_URL}/experiments/${slug}/realtime-unenrolls/`}
-                        title="Unenrollments (5min)"
-                        refreshMins={5}
-                        size={size}
-                    />
-                </div>
-            </article>
-        );
-    }
+    return (
+        <article id="experiment">
+            <h2>{slug}</h2>
+            <div className="monitoring-charts-remix">
+                <p>
+                    These are real-time enrollment charts for experiments that are not yet imported. Once
+                    the nightly import job finishes they will appear on the detailed experiment page.
+                </p>
+                <MonitoringChartContainer
+                    endpoint={`${process.env.REACT_APP_API_URL}/experiments/${slug}/realtime-enrolls/`}
+                    title="Enrollments (5min)"
+                    refreshMins={5}
+                    size={size}
+                />
+                <MonitoringChartContainer
+                    endpoint={`${process.env.REACT_APP_API_URL}/experiments/${slug}/realtime-unenrolls/`}
+                    title="Unenrollments (5min)"
+                    refreshMins={5}
+                    size={size}
+                />
+            </div>
+        </article>
+    );
 }
 
 export default withRouter(RealtimeExperimentContainer);

--- a/src/components/views/Experiment.js
+++ b/src/components/views/Experiment.js
@@ -23,6 +23,9 @@ export default class extends React.Component {
         // some metrics have more populations than others.
         this.populationColors = getDistinctColors(Object.keys(props.populations).length);
 
+        // Monitoring chart sizes.
+        this.monitorChartSize = {width: 600, height: 250};
+
         this.state = {
             showOutliers: props.showOutliers,
         };
@@ -150,28 +153,33 @@ export default class extends React.Component {
                     <div className="monitoring-charts">
                         <MonitoringChartContainer
                             colors={this.populationColors}
+                            size={this.monitorChartSize}
                             endpoint={`${process.env.REACT_APP_API_URL}/experiments/${this.props.slug}/enrolls/`}
                             title="Enrollments (hourly)"
                         />
                         <MonitoringChartContainer
                             colors={this.populationColors}
+                            size={this.monitorChartSize}
                             endpoint={`${process.env.REACT_APP_API_URL}/experiments/${this.props.slug}/unenrolls/`}
                             title="Unenrollments (hourly)"
                         />
                         <MonitoringChartContainer
                             colors={this.populationColors}
+                            size={this.monitorChartSize}
                             endpoint={`${process.env.REACT_APP_API_URL}/experiments/${this.props.slug}/realtime-enrolls/`}
                             title="Enrollments (5min)"
                             refreshMins={5}
                         />
                         <MonitoringChartContainer
                             colors={this.populationColors}
+                            size={this.monitorChartSize}
                             endpoint={`${process.env.REACT_APP_API_URL}/experiments/${this.props.slug}/realtime-unenrolls/`}
                             title="Unenrollments (5min)"
                             refreshMins={5}
                         />
                         <MonitoringChartContainer
                             colors={this.populationColors}
+                            size={{width: 1200, height: 350}}
                             endpoint={`${process.env.REACT_APP_API_URL}/experiments/${this.props.slug}/populations/`}
                             title="Populations"
                             fullWidth={true}

--- a/src/components/views/ExperimentsTable.js
+++ b/src/components/views/ExperimentsTable.js
@@ -8,6 +8,14 @@ import SearchBox from './SearchBox';
 import './css/ExperimentsTable.css';
 
 
+// Returns a table cell with link to either a regular or realtime details page.
+const getExperimentCell = experiment => {
+    if (experiment.realtime) {
+        return <td><Link to={`/realtime/${experiment.slug}/`}>{experiment.slug}</Link></td>;
+    }
+    return <td><Link to={`/experiments/${experiment.slug}/`}>{experiment.name || experiment.slug}</Link></td>;
+};
+
 export default props => {
     let maybePaginator = null;
     if (!props.searchActive) {
@@ -36,10 +44,8 @@ export default props => {
                 </thead>
                 <tbody>
                     {props.visibleExperiments.map((e, index) => (
-                        <tr key={index}>
-                            <td>
-                                <Link to={`/experiments/${e.slug}/`}>{e.name || e.slug}</Link>
-                            </td>
+                        <tr key={index} className={e.realtime ? 'realtime' : ''}>
+                            {getExperimentCell(e)}
                             <td>{e.creationDate && dateFormat(e.creationDate, 'longDate', true)}</td>
                         </tr>
                     ))}

--- a/src/components/views/Main.js
+++ b/src/components/views/Main.js
@@ -3,6 +3,7 @@ import { Switch, Route } from 'react-router-dom';
 
 import HomeContainer from '../containers/HomeContainer';
 import ExperimentContainer from '../containers/ExperimentContainer';
+import RealtimeExperimentContainer from '../containers/RealtimeExperimentContainer';
 
 
 export default () => (
@@ -10,6 +11,7 @@ export default () => (
         <Switch>
             <Route exact path="/" component={HomeContainer} />
             <Route exact path="/experiments/:experimentSlug" component={ExperimentContainer} />
+            <Route exact path="/realtime/:experimentSlug" component={RealtimeExperimentContainer} />
         </Switch>
     </main>
 );

--- a/src/components/views/MonitoringChart.js
+++ b/src/components/views/MonitoringChart.js
@@ -14,8 +14,8 @@ export default props => {
             <Plot
                 data={props.data}
                 layout={{
-                    width: props.fullWidth ? 1200 : 600,
-                    height: props.fullWidth ? 350 : 250,
+                    width: props.size.width,
+                    height: props.size.height,
                     yaxis: {
                         showline: true,
                         title: 'Clients',

--- a/src/components/views/styl/ExperimentsTable.styl
+++ b/src/components/views/styl/ExperimentsTable.styl
@@ -13,4 +13,42 @@
     .experiment-creation-date {
         width: 20%;
     }
+
+    tbody tr:hover {
+        background: linear-gradient(to right, #fff, #0083b0);
+        color: #fff;
+
+        a {
+            color: #0083b0;
+        }
+    }
+
+    // Styling tables is a disaster. This should not be needed (makes the last row the same as the others).
+    tbody tr:last-child {
+        line-height: 46.5px;
+
+        td {
+            padding: 0;
+
+            &:last-child {
+                padding-left: 15px;
+            }
+        }
+    }
+
+    .realtime {
+        a {
+            position: relative;
+
+            &::after {
+                content: "R";
+                font-size: 10px;
+                font-weight: 800;
+                position: absolute;
+                top: -5px;
+                color: #f00;
+                left: 100%;
+            }
+        }
+    }
 }

--- a/src/components/views/styl/MonitoringChart.styl
+++ b/src/components/views/styl/MonitoringChart.styl
@@ -10,3 +10,14 @@
         max-width: 50%;
     }
 }
+
+.monitoring-charts-remix {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.monitoring-chart {
+    display: flex;
+    justify-content: center;
+}


### PR DESCRIPTION
This requires a recent db copy from prod. I will try to make sure this branch remains deployed on staging.

We're introducing a new view for experiments flagged as 'realtime' so that the enrollment realtime charts can be shown without requiring the full post-import-job experiment. In other words to check the experiment health without waiting for the nightly job to finish.

The resultant page is quite barebones but them's the kicks.